### PR TITLE
Fix footer isset check

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <div class="footer">
-  {{ if isset .Site.Params "FooterMsg" }}
+  {{ if isset .Site.Params "footermsg" }}
   <p>{{ .Site.Params.FooterMsg | safeHTML }}</p>
   {{else}}
   <p>Powered by <a href="http://gohugo.io">Hugo</a>. This theme—Slim—Dark—is open sourced on <a href="https://github.com/oblitum/hugo-theme-slim">Github</a>.</p>


### PR DESCRIPTION
From https://gohugo.io/functions/isset/
 > All site-level configuration keys are stored as lower case. Therefore, a myParam key-value set in your site configuration file needs to be accessed with {{if isset .Site.Params "myparam"}} and not with {{if isset .Site.Params "myParam"}}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oblitum/hugo-theme-slim/1)
<!-- Reviewable:end -->
